### PR TITLE
fixed intent information for web survey

### DIFF
--- a/Examples/SnapinsChatSurvey/app/src/main/java/com/example/salesforce/SnapinsChatSurvey/MyChatListener.java
+++ b/Examples/SnapinsChatSurvey/app/src/main/java/com/example/salesforce/SnapinsChatSurvey/MyChatListener.java
@@ -70,28 +70,26 @@ public class MyChatListener implements SessionStateListener {
     surveyPrompt.setPositiveButton(R.string.survey_prompt_positive, new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
-
+            Intent intent;
             // Determine whether we should show a web view or a local UI
             // for the survey...
             if (mWebviewSurveyFlag) {
-              
+
               // You can launch a web view to display
               // a survey from the web. For example:
-              Intent intent = new Intent(mContext, WebViewSurveyActivity.class);
-              intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-              mContext.startActivity(intent);
-            }
-            else {
+              intent = new Intent(mContext, WebViewSurveyActivity.class);
+            } else {
 
               // Alternatively, you can launch code that
               // displays a survey with a local UI:
-              Intent intent = new Intent(mContext, LocalSurveyActivity.class);
-              intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-              intent.putExtra("visitor_name", mChatConfiguration.getVisitorName());
-              intent.putExtra("button_id", mChatConfiguration.getButtonId());
-              intent.putExtra("live_agent_pod", mChatConfiguration.getLiveAgentPod());
-              mContext.startActivity(intent);
+              intent = new Intent(mContext, LocalSurveyActivity.class);
+
             }
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.putExtra("visitor_name", mChatConfiguration.getVisitorName());
+            intent.putExtra("button_id", mChatConfiguration.getButtonId());
+            intent.putExtra("live_agent_pod", mChatConfiguration.getLiveAgentPod());
+            mContext.startActivity(intent);
           }
         }
     );

--- a/Examples/SnapinsChatSurvey/app/src/main/java/com/example/salesforce/SnapinsChatSurvey/WebViewSurveyActivity.java
+++ b/Examples/SnapinsChatSurvey/app/src/main/java/com/example/salesforce/SnapinsChatSurvey/WebViewSurveyActivity.java
@@ -6,12 +6,15 @@ import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
 
 /**
  * Activity that displays a web view to the survey.
  * This class isn't necessary if you plan to display a local UI survey.
  */
 public class WebViewSurveyActivity extends AppCompatActivity {
+
+  Bundle mExtras;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -40,9 +43,19 @@ public class WebViewSurveyActivity extends AppCompatActivity {
     webView.getSettings().setJavaScriptEnabled(true);
     webView.setWebViewClient(new WebViewClient());
 
+    // configuration information, potentially to connect a chat session and a survey session later
+    mExtras = getIntent().getExtras();
+
     // TODO: Replace this URL with your real survey URL...
     // URL to the dummy survey
     webView.loadUrl("https://qtrial2017q3az1.az1.qualtrics.com/jfe/form/SV_6mwOzsCqPhHH2eN");
+
+    // TODO: Do something with all this configuration information!
+    mExtras.get("visitor_name");
+    mExtras.get("button_id");
+    mExtras.get("live_agent_pod");
+    Toast.makeText(WebViewSurveyActivity.this, "This is where you do something with the configuration information...",
+        Toast.LENGTH_LONG).show();
   }
 
 }


### PR DESCRIPTION
Hey, I found some little mistakes that make a significant difference for the web activity having any information to track the survey data to a session, so I fixed them, and added a toast on the webActivity similar to the toast on the survey.