### PR TITLE
Maven repo update

### DIFF
--- a/releases/case/4.0.0/example.md
+++ b/releases/case/4.0.0/example.md
@@ -1,7 +1,7 @@
 ```
 repositories {
   jcenter()
-  maven { url 'https://salesforcesos.com/android/maven/release' }
+  maven { url 'http://salesforcesos.com.s3.amazonaws.com/android/maven/release' }
 }
 
 dependencies {

--- a/releases/chat/3.0.0/example.md
+++ b/releases/chat/3.0.0/example.md
@@ -1,6 +1,6 @@
 ```
 repositories {
-  maven { url 'https://salesforcesos.com/android/maven/release' }
+  maven { url 'http://salesforcesos.com.s3.amazonaws.com/android/maven/release' }
 }
 
 dependencies {

--- a/releases/knowledge/4.0.0/example.md
+++ b/releases/knowledge/4.0.0/example.md
@@ -1,6 +1,6 @@
 ```
 repositories {
-  maven { url 'https://salesforcesos.com/android/maven/release' }
+  maven { url 'http://salesforcesos.com.s3.amazonaws.com/android/maven/release' }
 }
 
 dependencies {

--- a/releases/sos/4.0.0/example.md
+++ b/releases/sos/4.0.0/example.md
@@ -1,7 +1,7 @@
 ```
 repositories {
   maven { url 'http://tokbox.bintray.com/maven/' }
-  maven { url 'https://salesforcesos.com/android/maven/release' }
+  maven { url 'http://salesforcesos.com.s3.amazonaws.com/android/maven/release' }
 }
 
 dependencies {


### PR DESCRIPTION
Updating the gradle example for the latest releases of each SDK to point directly to S3. This avoids an SSL cert error from salesforcesos.com. 

Related to #48 