### PR TITLE
Updating s3 repo urls

### DIFF
--- a/Examples/SnapinsChatSurvey/build.gradle
+++ b/Examples/SnapinsChatSurvey/build.gradle
@@ -19,7 +19,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://maven.google.com" }
-        maven { url 'https://salesforcesos.com/android/maven/release' }
+        maven { url 'https://s3.amazonaws.com/salesforcesos.com/android/maven/release' }
         maven { url 'http://tokbox.bintray.com/maven/' }
         google()
     }

--- a/Examples/SnapinsSDKExample/build.gradle
+++ b/Examples/SnapinsSDKExample/build.gradle
@@ -24,7 +24,7 @@ allprojects {
         mavenLocal()
         mavenCentral()
         maven { url "https://maven.google.com" }
-        maven { url "https://salesforcesos.com/android/maven/release" }
+        maven { url "https://s3.amazonaws.com/salesforcesos.com/android/maven/release" }
         maven { url "http://tokbox.bintray.com/maven/" }
     }
 }


### PR DESCRIPTION
Updating example projects to use the new s3 maven repository URLs. Related to #48 and #51.