### PR TITLE
Fix broken maven URL and use correct kotlin stdlib

### DIFF
--- a/Examples/SnapinsSDKExample/app/build.gradle
+++ b/Examples/SnapinsSDKExample/app/build.gradle
@@ -56,7 +56,7 @@ android {
 
 dependencies {
     // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Android
     implementation "com.android.support:appcompat-v7:$appCompatV7SupportVersion"

--- a/Examples/SnapinsSDKExample/build.gradle
+++ b/Examples/SnapinsSDKExample/build.gradle
@@ -6,7 +6,8 @@
  */
 
 buildscript {
-    ext.kotlin_version = "1.2.31"
+    ext.kotlin_version = "1.2.41"
+
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
We should be using `kotlin-stdlib-jdk7` instead of `kotlin:kotlin-stdlib-jre7`. Replaced `salesforcesos.com` with `https://s3.amazonaws.com/salesforcesos.com` as it is no longer in operation.