### PR TITLE
Updated to use the 216 pre-chat methods and classes.

### DIFF
--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.java
@@ -18,9 +18,11 @@ import com.salesforce.android.cases.ui.CaseUI;
 import com.salesforce.android.cases.ui.CaseUIClient;
 import com.salesforce.android.cases.ui.CaseUIConfiguration;
 import com.salesforce.android.chat.core.ChatConfiguration;
-import com.salesforce.android.chat.core.model.PreChatField;
+import com.salesforce.android.chat.core.model.ChatUserData;
 import com.salesforce.android.chat.ui.ChatUI;
 import com.salesforce.android.chat.ui.ChatUIClient;
+import com.salesforce.android.chat.ui.model.PreChatPickListField;
+import com.salesforce.android.chat.ui.model.PreChatTextInputField;
 import com.salesforce.android.knowledge.ui.KnowledgeScene;
 import com.salesforce.android.knowledge.ui.KnowledgeViewAddition;
 import com.salesforce.android.service.common.utilities.control.Async;
@@ -138,7 +140,7 @@ public class SupportHomeViewAddition implements KnowledgeViewAddition{
         // Show an alert if any argument is invalid
         try {
             chatConfiguration = ServiceSDKUtils.getChatConfigurationBuilder(context)
-                    .preChatFields(buildPreChatFields())
+                    .chatUserData(buildPreChatFields())
                     .build();
         } catch (IllegalArgumentException e) {
             showConfigurationErrorAlertDialog(e.getMessage());
@@ -166,29 +168,27 @@ public class SupportHomeViewAddition implements KnowledgeViewAddition{
     /**
      * Configures pre chat fields if prechat is enabled in settings
      */
-    private List<PreChatField> buildPreChatFields(){
+    private List<ChatUserData> buildPreChatFields(){
         // Create a pre-chat field for the user's name if it's enabled
-        PreChatField preChatField1 = new PreChatField.Builder()
+        ChatUserData preChatField1 = new PreChatTextInputField.Builder()
                     .build(context.getString(R.string.prechat_agent_info_label),
-                            context.getString(R.string.prechat_enter_name_label),
-                            PreChatField.STRING);
+                            context.getString(R.string.prechat_enter_name_label));
 
         // Create a pre-chat picklist field that has selecting pre-defined values
-        PreChatField preChatField2 = new PreChatField.Builder()
+        ChatUserData preChatField2 = new PreChatPickListField.Builder()
                 .required(true)
-                .addPickListOption(new PreChatField.PickListOption(
-                        context.getString(R.string.prechat_example_id) + '1',
-                        context.getString(R.string.prechat_example_selection_one)))
-                .addPickListOption(new PreChatField.PickListOption(
-                        context.getString(R.string.prechat_example_id) + 2,
-                        context.getString(R.string.prechat_example_selection_two)))
+                .addOption(new PreChatPickListField.Option(
+                        context.getString(R.string.prechat_example_selection_one),
+                        context.getString(R.string.prechat_example_id_one)))
+                .addOption(new PreChatPickListField.Option(
+                        context.getString(R.string.prechat_example_selection_two),
+                        context.getString(R.string.prechat_example_id_two)))
                 .build(context.getString(R.string.prechat_agent_info_label),
-                        context.getString(R.string.prechat_selection_label_title),
-                        PreChatField.PICKLIST);
+                        context.getString(R.string.prechat_selection_label_title));
 
         return preChatEnabled()
                 ? Utils.asMutableList(preChatField1, preChatField2)
-                : Collections.<PreChatField>emptyList();
+                : Collections.<ChatUserData>emptyList();
     }
 
     /**

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.kt
@@ -25,9 +25,11 @@ import com.salesforce.android.cases.core.CaseClientCallbacks
 import com.salesforce.android.cases.ui.CaseUI
 import com.salesforce.android.cases.ui.CaseUIConfiguration
 import com.salesforce.android.chat.core.ChatConfiguration
-import com.salesforce.android.chat.core.model.PreChatField
+import com.salesforce.android.chat.core.model.ChatUserData
 import com.salesforce.android.chat.ui.ChatUI
 import com.salesforce.android.chat.ui.ChatUIClient
+import com.salesforce.android.chat.ui.model.PreChatPickListField
+import com.salesforce.android.chat.ui.model.PreChatTextInputField
 import com.salesforce.android.knowledge.ui.KnowledgeScene
 import com.salesforce.android.knowledge.ui.KnowledgeViewAddition
 import com.salesforce.android.sos.api.Sos
@@ -117,7 +119,7 @@ class SupportHomeViewAddition: KnowledgeViewAddition {
         // Try to build a chat configuration, show an alert if any argument is invalid
         try {
             chatConfiguration = ServiceSDKUtils.getChatConfigurationBuilder(context)
-                    .preChatFields(buildPreChatFields())
+                    .chatUserData(buildPreChatFields())
                     .build()
         } catch (e: IllegalArgumentException) {
             showConfigurationErrorAlertDialog(e.message)
@@ -144,25 +146,23 @@ class SupportHomeViewAddition: KnowledgeViewAddition {
     /**
      * Configures pre chat fields if prechat is enabled in settings
      */
-    private fun buildPreChatFields(): MutableList<PreChatField>? {
+    private fun buildPreChatFields(): MutableList<ChatUserData> {
         return if (preChatEnabled())
             Utils.asMutableList(
-                    PreChatField.Builder()
+                    PreChatTextInputField.Builder()
                             .build(context.getString(R.string.prechat_agent_info_label),
-                                    context.getString(R.string.prechat_enter_name_label),
-                                    PreChatField.STRING),
+                                    context.getString(R.string.prechat_enter_name_label)),
                     // A required picklist field
-                    PreChatField.Builder()
+                    PreChatPickListField.Builder()
                             .required(true)
-                            .addPickListOption(PreChatField.PickListOption(
-                                    String.format(context.getString(R.string.prechat_example_id), 1),
-                                    context.getString(R.string.prechat_example_selection_one)))
-                            .addPickListOption(PreChatField.PickListOption(
-                                    String.format(context.getString(R.string.prechat_example_id), 2),
-                                    context.getString(R.string.prechat_example_selection_two)))
+                            .addOption(PreChatPickListField.Option(
+                                    context.getString(R.string.prechat_example_selection_one),
+                                    context.getString(R.string.prechat_example_id_one)))
+                            .addOption(PreChatPickListField.Option(
+                                    context.getString(R.string.prechat_example_selection_two),
+                                    context.getString(R.string.prechat_example_id_two)))
                             .build(context.getString(R.string.prechat_agent_info_label),
-                                    context.getString(R.string.prechat_selection_label_title),
-                                    PreChatField.PICKLIST)
+                                    context.getString(R.string.prechat_selection_label_title))
             )
         else Collections.emptyList()
     }

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/utils/Utils.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/utils/Utils.kt
@@ -11,7 +11,7 @@ import android.content.Context
 import android.preference.PreferenceManager
 
 object Utils {
-    fun<T> asMutableList(vararg t: T): MutableList<T>? {
+    fun<T> asMutableList(vararg t: T): MutableList<T> {
         val result = ArrayList<T>()
         result += t
         return result

--- a/Examples/SnapinsSDKExample/app/src/main/res/values/strings.xml
+++ b/Examples/SnapinsSDKExample/app/src/main/res/values/strings.xml
@@ -123,9 +123,10 @@
     <string name="pref_chat_button_id_summary">The Chat Button Id to use</string>
     <string name="prechat_agent_info_label">Agent Info Label</string>
     <string name="prechat_enter_name_label">Enter Name</string>
-    <string name="prechat_example_id">ID%1$s</string>
-    <string name="prechat_example_selection_one">Example Seletion 1</string>
-    <string name="prechat_example_selection_two">Example Seletion 2</string>
+    <string name="prechat_example_id_one">ID1</string>
+    <string name="prechat_example_id_two">ID2</string>
+    <string name="prechat_example_selection_one">Example Selection 1</string>
+    <string name="prechat_example_selection_two">Example Selection 2</string>
     <string name="prechat_selection_label_title">Selection Label Title</string>
     <string name="chat_availability_change_message">Agent Chat Status: %1$s</string>
 


### PR DESCRIPTION
@rileymacdonald-sf Let me know what you think about these updates to the examples. Now it no longer uses deprecated pre-chat methods and classes. Also fixed two little bugs with the picklist (parsing didn't work properly in the Java variant and also the args were in the wrong order).