### PR TITLE
Added a better pre-chat example

### DIFF
--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.java
@@ -6,7 +6,6 @@ import com.salesforce.android.chat.core.model.ChatEntityField;
 import com.salesforce.android.chat.core.model.ChatUserData;
 import com.salesforce.android.chat.ui.ChatUI;
 import com.salesforce.android.chat.ui.ChatUIClient;
-import com.salesforce.android.chat.ui.model.PreChatPickListField;
 import com.salesforce.android.chat.ui.model.PreChatTextInputField;
 import com.salesforce.android.service.common.utilities.control.Async;
 import com.salesforce.snapinssdkexample.activities.settings.ChatSettingsActivity;

--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.java
@@ -108,7 +108,7 @@ public class ChatLauncher {
 
         // Create an entity mapping for a Case record type
         // (All this entity stuff is only required if you
-        // want to map transcript fields to other Salesforce records.)
+        // want to map pre-chat fields to other Salesforce records.)
         ChatEntity caseEntity = new ChatEntity.Builder()
                 .showOnCreate(true)
                 .linkToTranscriptField("Case")
@@ -146,7 +146,7 @@ public class ChatLauncher {
                 .build("Contact");
 
         // Update chat entity mapping list
-        // (This is only required if you want to map transcript
+        // (This is only required if you want to map pre-chat
         // fields to other Salesforce records.)
         chatEntities = Utils.asMutableList(caseEntity, contactEntity);
     }

--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.java
@@ -1,0 +1,170 @@
+package com.salesforce.snapinssdkexample;
+
+import com.salesforce.android.chat.core.ChatConfiguration;
+import com.salesforce.android.chat.core.model.ChatEntity;
+import com.salesforce.android.chat.core.model.ChatEntityField;
+import com.salesforce.android.chat.core.model.ChatUserData;
+import com.salesforce.android.chat.ui.ChatUI;
+import com.salesforce.android.chat.ui.ChatUIClient;
+import com.salesforce.android.chat.ui.model.PreChatPickListField;
+import com.salesforce.android.chat.ui.model.PreChatTextInputField;
+import com.salesforce.android.service.common.utilities.control.Async;
+import com.salesforce.snapinssdkexample.activities.settings.ChatSettingsActivity;
+import com.salesforce.snapinssdkexample.utils.ServiceSDKUtils;
+import com.salesforce.snapinssdkexample.utils.Utils;
+
+import java.util.Collections;
+import java.util.List;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.view.inputmethod.EditorInfo;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+
+import static com.salesforce.snapinssdkexample.utils.Utils.getBooleanPref;
+
+public class ChatLauncher {
+    private Context context;
+    private List<ChatUserData> chatUserData;
+    private List<ChatEntity> chatEntities;
+
+    /**
+     * Configures and launches Live Agent Chat
+     */
+    public void launchChat(final Context context) {
+        this.context = context;
+
+        ChatConfiguration chatConfiguration;
+
+        initializePreChatData();
+
+        // Create a UI configuration instance from a core config object
+        // Show an alert if any argument is invalid
+        try {
+            chatConfiguration = ServiceSDKUtils.getChatConfigurationBuilder(context)
+                    .chatUserData(chatUserData)
+                    .chatEntities(chatEntities)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            showConfigurationErrorAlertDialog(e.getMessage());
+            return;
+        }
+
+        // Configure chat session listener
+        ServiceSDKApplication serviceSDKApplication = (ServiceSDKApplication) context.getApplicationContext();
+        final ChatSessionListener chatListener = serviceSDKApplication.getChatSessionListener();
+
+        // Create the chat UI from the ChatUIConfiguration object
+        ChatUI.configure(ServiceSDKUtils.getChatUIConfigurationBuilder(context, chatConfiguration).build())
+                .createClient(context)
+                .onResult(new Async.ResultHandler<ChatUIClient>() {
+                    @Override
+                    public void handleResult(Async<?> async, @NonNull ChatUIClient chatUIClient) {
+                        // Add the configured chat session listener to the Chat UI client
+                        chatUIClient.addSessionStateListener(chatListener);
+                        // Start the live agent chat session
+                        chatUIClient.startChatSession((FragmentActivity) context);
+                    }
+                });
+    }
+
+    /**
+     * Configures pre-chat fields if pre-chat is enabled in settings
+     */
+    private void initializePreChatData() {
+
+        if (!preChatEnabled()) {
+            chatUserData = Collections.<ChatUserData>emptyList();
+            chatEntities = Collections.<ChatEntity>emptyList();
+            return;
+        }
+
+        // Create some basic pre-chat fields (with user input)
+        PreChatTextInputField firstName = new PreChatTextInputField.Builder()
+                .required(true)
+                .build("Please enter your first name", "First Name");
+
+        PreChatTextInputField lastName = new PreChatTextInputField.Builder()
+                .required(true)
+                .build("Please enter your last name", "Last Name");
+
+        PreChatTextInputField email = new PreChatTextInputField.Builder()
+                .required(true)
+                .inputType(EditorInfo.TYPE_TEXT_VARIATION_EMAIL_ADDRESS)
+                .mapToChatTranscriptFieldName("Email__c")
+                .build("Please enter your email", "Email Address");
+
+        // Create a pre-chat field without user input
+        // (This illustrates a good way to directly send data to your org.)
+        ChatUserData subject = new ChatUserData(
+                "Hidden Subject Field",
+                "Chat case created by sample Android app",
+                false);
+
+        // Update chat user data list
+        chatUserData = Utils.asMutableList(firstName, lastName, email, subject);
+
+        // Create an entity mapping for a Case record type
+        // (All this entity stuff is only required if you
+        // want to map transcript fields to other Salesforce records.)
+        ChatEntity caseEntity = new ChatEntity.Builder()
+                .showOnCreate(true)
+                .linkToTranscriptField("Case")
+                .addChatEntityField(
+                        new ChatEntityField.Builder()
+                                .doFind(true)
+                                .isExactMatch(true)
+                                .doCreate(true)
+                                .build("Subject", subject))
+                .build("Case");
+
+        // Create an entity mapping for a Contact record type
+        ChatEntity contactEntity = new ChatEntity.Builder()
+                .showOnCreate(true)
+                .linkToTranscriptField("Contact")
+                .linkToAnotherSalesforceObject(caseEntity, "ContactId")
+                .addChatEntityField(
+                        new ChatEntityField.Builder()
+                                .doFind(true)
+                                .isExactMatch(true)
+                                .doCreate(true)
+                                .build("FirstName", firstName))
+                .addChatEntityField(
+                        new ChatEntityField.Builder()
+                                .doFind(true)
+                                .isExactMatch(true)
+                                .doCreate(true)
+                                .build("LastName", lastName))
+                .addChatEntityField(
+                        new ChatEntityField.Builder()
+                                .doFind(true)
+                                .isExactMatch(true)
+                                .doCreate(true)
+                                .build("Email", email))
+                .build("Contact");
+
+        // Update chat entity mapping list
+        // (This is only required if you want to map transcript
+        // fields to other Salesforce records.)
+        chatEntities = Utils.asMutableList(caseEntity, contactEntity);
+    }
+
+    /**
+     * Helper method to determine if pre chat is enabled
+     */
+    private boolean preChatEnabled() {
+        return getBooleanPref(
+                context, ChatSettingsActivity.KEY_PRECHAT_ENABLED);
+    }
+
+    private void showConfigurationErrorAlertDialog(String message) {
+        AlertDialog dialog = new AlertDialog.Builder(context)
+                .setPositiveButton(context.getString(R.string.ok), null)
+                .setMessage(context.getString(R.string.config_error_prefix, message))
+                .create();
+
+        dialog.show();
+    }
+}

--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.java
@@ -132,69 +132,8 @@ public class SupportHomeViewAddition implements KnowledgeViewAddition {
      * Configures and launches Live Agent Chat
      */
     private void launchChat() {
-        ChatConfiguration chatConfiguration;
-
-        // Create a UI configuration instance from a core config object
-        // Show an alert if any argument is invalid
-        try {
-            chatConfiguration = ServiceSDKUtils.getChatConfigurationBuilder(context)
-                    .chatUserData(buildPreChatFields())
-                    .build();
-        } catch (IllegalArgumentException e) {
-            showConfigurationErrorAlertDialog(e.getMessage());
-            return;
-        }
-
-        // Configure chat session listener
-        ServiceSDKApplication serviceSDKApplication = (ServiceSDKApplication) context.getApplicationContext();
-        final ChatSessionListener chatListener = serviceSDKApplication.getChatSessionListener();
-
-        // Create the chat UI from the ChatUIConfiguration object
-        ChatUI.configure(ServiceSDKUtils.getChatUIConfigurationBuilder(context, chatConfiguration).build())
-                .createClient(context)
-                .onResult(new Async.ResultHandler<ChatUIClient>() {
-                    @Override
-                    public void handleResult(Async<?> async, @NonNull ChatUIClient chatUIClient) {
-                        // Add the configured chat session listener to the Chat UI client
-                        chatUIClient.addSessionStateListener(chatListener);
-                        // Start the live agent chat session
-                        chatUIClient.startChatSession((FragmentActivity) context);
-                    }
-                });
-    }
-
-    /**
-     * Configures pre chat fields if prechat is enabled in settings
-     */
-    private List<ChatUserData> buildPreChatFields() {
-        // Create a pre-chat field for the user's name if it's enabled
-        ChatUserData preChatField1 = new PreChatTextInputField.Builder()
-                .build(context.getString(R.string.prechat_agent_info_label),
-                        context.getString(R.string.prechat_enter_name_label));
-
-        // Create a pre-chat picklist field that has selecting pre-defined values
-        ChatUserData preChatField2 = new PreChatPickListField.Builder()
-                .required(true)
-                .addOption(new PreChatPickListField.Option(
-                        context.getString(R.string.prechat_example_selection_one),
-                        context.getString(R.string.prechat_example_id_one)))
-                .addOption(new PreChatPickListField.Option(
-                        context.getString(R.string.prechat_example_selection_two),
-                        context.getString(R.string.prechat_example_id_two)))
-                .build(context.getString(R.string.prechat_agent_info_label),
-                        context.getString(R.string.prechat_selection_label_title));
-
-        return preChatEnabled()
-                ? Utils.asMutableList(preChatField1, preChatField2)
-                : Collections.<ChatUserData>emptyList();
-    }
-
-    /**
-     * Helper method to determine if pre chat is enabled
-     */
-    private boolean preChatEnabled() {
-        return getBooleanPref(
-                context, ChatSettingsActivity.KEY_PRECHAT_ENABLED);
+        ChatLauncher chat = new ChatLauncher();
+        chat.launchChat(this.context);
     }
 
     /**

--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.java
@@ -11,33 +11,20 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentActivity;
 import com.salesforce.android.cases.core.CaseClientCallbacks;
 import com.salesforce.android.cases.ui.CaseUI;
 import com.salesforce.android.cases.ui.CaseUIClient;
 import com.salesforce.android.cases.ui.CaseUIConfiguration;
-import com.salesforce.android.chat.core.ChatConfiguration;
-import com.salesforce.android.chat.core.model.ChatUserData;
-import com.salesforce.android.chat.ui.ChatUI;
-import com.salesforce.android.chat.ui.ChatUIClient;
-import com.salesforce.android.chat.ui.model.PreChatPickListField;
-import com.salesforce.android.chat.ui.model.PreChatTextInputField;
 import com.salesforce.android.knowledge.ui.KnowledgeScene;
 import com.salesforce.android.knowledge.ui.KnowledgeViewAddition;
 import com.salesforce.android.service.common.utilities.control.Async;
 import com.salesforce.android.sos.api.Sos;
-import com.salesforce.snapinssdkexample.activities.settings.ChatSettingsActivity;
 import com.salesforce.snapinssdkexample.utils.ServiceSDKUtils;
-import com.salesforce.snapinssdkexample.utils.Utils;
 import io.github.yavski.fabspeeddial.FabSpeedDial;
 import io.github.yavski.fabspeeddial.SimpleMenuListenerAdapter;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
-import static com.salesforce.snapinssdkexample.utils.Utils.getBooleanPref;
 
 /**
  * An addition to display Knowledge. Cases, Chat and SOS are launched from here as an example of

--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/activities/MainActivity.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/activities/MainActivity.java
@@ -23,6 +23,7 @@ import com.salesforce.android.sos.api.SosAvailability;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.rest.RestClient;
+import com.salesforce.snapinssdkexample.ChatLauncher;
 import com.salesforce.snapinssdkexample.R;
 import com.salesforce.snapinssdkexample.SupportHomeViewAddition;
 import com.salesforce.snapinssdkexample.activities.settings.CaseSettingsActivity;
@@ -44,6 +45,7 @@ public class MainActivity extends AppCompatActivity implements SosAvailability.L
     private KnowledgeUI mKnowledgeUI;
     private KnowledgeUIClient mKnowledgeUIClient;
     private TextView knowledgeLaunchButton;
+    private Button chatButton;
     private Button loginButton;
     private Button logoutButton;
 
@@ -54,6 +56,7 @@ public class MainActivity extends AppCompatActivity implements SosAvailability.L
         Toolbar toolbar = findViewById(R.id.toolbar);
 
         knowledgeLaunchButton = findViewById(R.id.knowledge_launch_button);
+        chatButton = findViewById(R.id.chat_launch_button);
         loginButton = findViewById(R.id.login_button);
         logoutButton = findViewById(R.id.logout_button);
 
@@ -187,6 +190,12 @@ public class MainActivity extends AppCompatActivity implements SosAvailability.L
                 launchKnowledge();
             }
         });
+        chatButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                launchChat();
+            }
+        });
         loginButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -199,6 +208,14 @@ public class MainActivity extends AppCompatActivity implements SosAvailability.L
                 logout();
             }
         });
+    }
+
+    /**
+     * Launches Chat.
+     */
+    private void launchChat() {
+        ChatLauncher chat = new ChatLauncher();
+        chat.launchChat(this);
     }
 
     /**

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.kt
@@ -10,7 +10,6 @@ import com.salesforce.android.chat.core.model.ChatEntityField
 import com.salesforce.android.chat.core.model.ChatUserData
 import com.salesforce.android.chat.ui.ChatUI
 import com.salesforce.android.chat.ui.ChatUIClient
-import com.salesforce.android.chat.ui.model.PreChatPickListField
 import com.salesforce.android.chat.ui.model.PreChatTextInputField
 import com.salesforce.snapinssdkexample.activities.settings.ChatSettingsActivity
 import com.salesforce.snapinssdkexample.utils.ServiceSDKUtils

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.kt
@@ -98,7 +98,7 @@ class ChatLauncher {
 
         // Create an entity mapping for a Case record type
         // (All this entity stuff is only required if you
-        // want to map transcript fields to other Salesforce records.)
+        // want to map pre-chat fields to other Salesforce records.)
         val caseEntity = ChatEntity.Builder()
                 .showOnCreate(true)
                 .linkToTranscriptField("Case")
@@ -136,7 +136,7 @@ class ChatLauncher {
                 .build("Contact")
 
         // Update chat entity mapping list
-        // (This is only required if you want to map transcript
+        // (This is only required if you want to map pre-chat
         // fields to other Salesforce records.)
         chatEntitiesList = Utils.asMutableList(caseEntity, contactEntity)
     }

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.kt
@@ -1,0 +1,160 @@
+package com.salesforce.snapinssdkexample
+
+import android.app.AlertDialog
+import android.content.Context
+import android.view.inputmethod.EditorInfo
+import androidx.fragment.app.FragmentActivity
+import com.salesforce.android.chat.core.ChatConfiguration
+import com.salesforce.android.chat.core.model.ChatEntity
+import com.salesforce.android.chat.core.model.ChatEntityField
+import com.salesforce.android.chat.core.model.ChatUserData
+import com.salesforce.android.chat.ui.ChatUI
+import com.salesforce.android.chat.ui.ChatUIClient
+import com.salesforce.android.chat.ui.model.PreChatPickListField
+import com.salesforce.android.chat.ui.model.PreChatTextInputField
+import com.salesforce.snapinssdkexample.activities.settings.ChatSettingsActivity
+import com.salesforce.snapinssdkexample.utils.ServiceSDKUtils
+import com.salesforce.snapinssdkexample.utils.Utils
+import java.util.*
+
+class ChatLauncher {
+    lateinit var context: Context
+
+    private var chatUserDataList: MutableList<ChatUserData> = Collections.emptyList()
+    private var chatEntitiesList: MutableList<ChatEntity> = Collections.emptyList()
+
+    /**
+     * Configures and launches Live Agent Chat
+     */
+    fun launchChat(context: Context) {
+        this.context = context
+
+        // Create a UI configuration instance from a core config object
+        var chatConfiguration: ChatConfiguration? = null
+
+        initializePreChatData()
+
+        // Try to build a chat configuration, show an alert if any argument is invalid
+        try {
+            chatConfiguration = ServiceSDKUtils.getChatConfigurationBuilder(context)
+                    .chatUserData(chatUserDataList)
+                    .chatEntities(chatEntitiesList)
+                    .build()
+        } catch (e: IllegalArgumentException) {
+            showConfigurationErrorAlertDialog(e.message)
+        }
+
+        // Configure chat session listener
+        val serviceSDKApplication = context.applicationContext as ServiceSDKApplication
+        val chatListener = serviceSDKApplication.chatSessionListener
+
+        chatConfiguration?.let {
+            ChatUI.configure(ServiceSDKUtils.getChatUIConfigurationBuilder(context, it).build())
+                    .createClient(context)
+                    .onResult { _, chatUIClient: ChatUIClient ->
+                        run {
+                            // Add the configured chat session listener to the Chat UI client
+                            chatUIClient.addSessionStateListener(chatListener)
+                            // Start the live agent chat session
+                            chatUIClient.startChatSession(context as FragmentActivity)
+                        }
+                    }
+        }
+    }
+
+    /**
+     * Configures pre-chat fields if pre-chat is enabled in settings
+     */
+    private fun initializePreChatData() {
+
+        if (!preChatEnabled()) {
+            return
+        }
+
+        // Create some basic pre-chat fields (with user input)
+        val firstName = PreChatTextInputField.Builder()
+                .required(true)
+                .build("Please enter your first name", "First Name")
+
+        val lastName = PreChatTextInputField.Builder()
+                .required(true)
+                .build("Please enter your last name", "Last Name")
+
+        val email = PreChatTextInputField.Builder()
+                .required(true)
+                .inputType(EditorInfo.TYPE_TEXT_VARIATION_EMAIL_ADDRESS)
+                .mapToChatTranscriptFieldName("Email__c")
+                .build("Please enter your email", "Email Address")
+
+        // Create a pre-chat field without user input
+        // (This illustrates a good way to directly send data to your org.)
+        val subject = ChatUserData(
+                "Hidden Subject Field",
+                "Chat case created by sample Android Kotlin app",
+                false)
+
+        // Update chat user data list
+        chatUserDataList = Utils.asMutableList(firstName, lastName, email, subject)
+
+        // Create an entity mapping for a Case record type
+        // (All this entity stuff is only required if you
+        // want to map transcript fields to other Salesforce records.)
+        val caseEntity = ChatEntity.Builder()
+                .showOnCreate(true)
+                .linkToTranscriptField("Case")
+                .addChatEntityField(
+                        ChatEntityField.Builder()
+                                .doFind(true)
+                                .isExactMatch(true)
+                                .doCreate(true)
+                                .build("Subject", subject))
+                .build("Case")
+
+        // Create an entity mapping for a Contact record type
+        val contactEntity = ChatEntity.Builder()
+                .showOnCreate(true)
+                .linkToTranscriptField("Contact")
+                .linkToAnotherSalesforceObject(caseEntity, "ContactId")
+                .addChatEntityField(
+                        ChatEntityField.Builder()
+                                .doFind(true)
+                                .isExactMatch(true)
+                                .doCreate(true)
+                                .build("FirstName", firstName))
+                .addChatEntityField(
+                        ChatEntityField.Builder()
+                                .doFind(true)
+                                .isExactMatch(true)
+                                .doCreate(true)
+                                .build("LastName", lastName))
+                .addChatEntityField(
+                        ChatEntityField.Builder()
+                                .doFind(true)
+                                .isExactMatch(true)
+                                .doCreate(true)
+                                .build("Email", email))
+                .build("Contact")
+
+        // Update chat entity mapping list
+        // (This is only required if you want to map transcript
+        // fields to other Salesforce records.)
+        chatEntitiesList = Utils.asMutableList(caseEntity, contactEntity)
+    }
+
+    /**
+     * Helper method to determine if pre chat is enabled
+     */
+    private fun preChatEnabled(): Boolean {
+        return Utils.getBooleanPref(
+                context, ChatSettingsActivity.KEY_PRECHAT_ENABLED)
+    }
+
+    private fun showConfigurationErrorAlertDialog(message: String?) {
+        message.let {
+            AlertDialog.Builder(context).setPositiveButton(context.getString(R.string.ok), null)
+                    .setMessage(context.getString(R.string.config_error_prefix, message))
+                    .create().show()
+        }
+    }
+
+}

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.kt
@@ -17,25 +17,15 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.FragmentActivity
 import com.salesforce.android.cases.core.CaseClientCallbacks
 import com.salesforce.android.cases.ui.CaseUI
 import com.salesforce.android.cases.ui.CaseUIConfiguration
-import com.salesforce.android.chat.core.ChatConfiguration
-import com.salesforce.android.chat.core.model.ChatUserData
-import com.salesforce.android.chat.ui.ChatUI
-import com.salesforce.android.chat.ui.ChatUIClient
-import com.salesforce.android.chat.ui.model.PreChatPickListField
-import com.salesforce.android.chat.ui.model.PreChatTextInputField
 import com.salesforce.android.knowledge.ui.KnowledgeScene
 import com.salesforce.android.knowledge.ui.KnowledgeViewAddition
 import com.salesforce.android.sos.api.Sos
-import com.salesforce.snapinssdkexample.activities.settings.ChatSettingsActivity
 import com.salesforce.snapinssdkexample.utils.ServiceSDKUtils
-import com.salesforce.snapinssdkexample.utils.Utils
 import io.github.yavski.fabspeeddial.FabSpeedDial
 import io.github.yavski.fabspeeddial.SimpleMenuListenerAdapter
-import java.util.*
 
 /**
  * An addition to display Knowledge. Cases, Chat and SOS are launched from here as an example of

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/SupportHomeViewAddition.kt
@@ -113,66 +113,8 @@ class SupportHomeViewAddition : KnowledgeViewAddition {
      * Configures and launches Live Agent Chat
      */
     private fun launchChat() {
-        // Create a UI configuration instance from a core config object
-        var chatConfiguration: ChatConfiguration? = null
-
-        // Try to build a chat configuration, show an alert if any argument is invalid
-        try {
-            chatConfiguration = ServiceSDKUtils.getChatConfigurationBuilder(context)
-                    .chatUserData(buildPreChatFields())
-                    .build()
-        } catch (e: IllegalArgumentException) {
-            showConfigurationErrorAlertDialog(e.message)
-        }
-
-        // Configure chat session listener
-        val serviceSDKApplication = context.applicationContext as ServiceSDKApplication
-        val chatListener = serviceSDKApplication.chatSessionListener
-
-        chatConfiguration?.let {
-            ChatUI.configure(ServiceSDKUtils.getChatUIConfigurationBuilder(context, it).build())
-                    .createClient(context)
-                    .onResult { _, chatUIClient: ChatUIClient ->
-                        run {
-                            // Add the configued chat session listener to the Chat UI client
-                            chatUIClient.addSessionStateListener(chatListener)
-                            // Start the live agent chat session
-                            chatUIClient.startChatSession(context as FragmentActivity)
-                        }
-                    }
-        }
-    }
-
-    /**
-     * Configures pre chat fields if prechat is enabled in settings
-     */
-    private fun buildPreChatFields(): MutableList<ChatUserData> {
-        return if (preChatEnabled())
-            Utils.asMutableList(
-                    PreChatTextInputField.Builder()
-                            .build(context.getString(R.string.prechat_agent_info_label),
-                                    context.getString(R.string.prechat_enter_name_label)),
-                    // A required picklist field
-                    PreChatPickListField.Builder()
-                            .required(true)
-                            .addOption(PreChatPickListField.Option(
-                                    context.getString(R.string.prechat_example_selection_one),
-                                    context.getString(R.string.prechat_example_id_one)))
-                            .addOption(PreChatPickListField.Option(
-                                    context.getString(R.string.prechat_example_selection_two),
-                                    context.getString(R.string.prechat_example_id_two)))
-                            .build(context.getString(R.string.prechat_agent_info_label),
-                                    context.getString(R.string.prechat_selection_label_title))
-            )
-        else Collections.emptyList()
-    }
-
-    /**
-     * Helper method to determine if pre chat is enabled
-     */
-    private fun preChatEnabled(): Boolean {
-        return Utils.getBooleanPref(
-                context, ChatSettingsActivity.KEY_PRECHAT_ENABLED)
+        val chat = ChatLauncher()
+        chat.launchChat(context)
     }
 
     /**

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/activities/MainActivity.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/activities/MainActivity.kt
@@ -22,6 +22,7 @@ import com.salesforce.android.service.common.utilities.control.Async
 import com.salesforce.android.sos.api.SosAvailability
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.rest.RestClient
+import com.salesforce.snapinssdkexample.ChatLauncher
 import com.salesforce.snapinssdkexample.R
 import com.salesforce.snapinssdkexample.SupportHomeViewAddition
 import com.salesforce.snapinssdkexample.activities.settings.CaseSettingsActivity
@@ -99,14 +100,14 @@ class MainActivity : AppCompatActivity(), SosAvailability.Listener {
 
         // Create an agent availability client
         ChatCore.configureAgentAvailability(chatConfig).check()
-                .onResult({ _: Async<*>?, state: AvailabilityState ->
+                .onResult { _: Async<*>?, state: AvailabilityState ->
                     run {
                         // Display a toast when any agent availability state is changed
                         Toast.makeText(this,
                                 String.format(getString(R.string.chat_availability_change_message), state.status.toString()),
                                 Toast.LENGTH_SHORT).show()
                     }
-                })
+                }
 
         return true
     }
@@ -153,6 +154,7 @@ class MainActivity : AppCompatActivity(), SosAvailability.Listener {
      */
     private fun setupButtons() {
         knowledge_launch_button.setOnClickListener { launchKnowledge() }
+        chat_launch_button.setOnClickListener({ startChat() })
         login_button.setOnClickListener({ login() })
         logout_button.setOnClickListener({ logout() })
     }
@@ -167,6 +169,14 @@ class MainActivity : AppCompatActivity(), SosAvailability.Listener {
             // Add the view addition
             mKnowledgeUI?.viewAddition(SupportHomeViewAddition())
         }
+    }
+
+    /**
+     * Initializes Knowledge and adds the view addition.
+     */
+    private fun startChat() {
+        val chat = ChatLauncher()
+        chat.launchChat(this)
     }
 
     /**
@@ -197,11 +207,11 @@ class MainActivity : AppCompatActivity(), SosAvailability.Listener {
      * Initiates user login process.
      */
     private fun login() {
-        SalesforceSDKManager.getInstance().clientManager.getRestClient(this, { client: RestClient ->
+        SalesforceSDKManager.getInstance().clientManager.getRestClient(this) { client: RestClient ->
             run {
                 // left blank intentionally
             }
-        })
+        }
     }
 
     /**

--- a/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/activities/MainActivity.kt
+++ b/Examples/SnapinsSDKExample/app/src/kotlinImplDebug/java/com/salesforce/snapinssdkexample/activities/MainActivity.kt
@@ -172,7 +172,7 @@ class MainActivity : AppCompatActivity(), SosAvailability.Listener {
     }
 
     /**
-     * Initializes Knowledge and adds the view addition.
+     * Initializes Chat.
      */
     private fun startChat() {
         val chat = ChatLauncher()

--- a/Examples/SnapinsSDKExample/app/src/main/res/layout/content_main.xml
+++ b/Examples/SnapinsSDKExample/app/src/main/res/layout/content_main.xml
@@ -15,20 +15,6 @@
     tools:showIn="@layout/activity_main">
 
     <TextView
-        android:id="@+id/auth_title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="16dp"
-        android:text="@string/authentication_description_title"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/knowledge_launch_button" />
-
-    <TextView
         android:id="@+id/kb_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -43,7 +29,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/knowledge_descrption_text"
+        android:id="@+id/knowledge_description_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
@@ -61,9 +47,60 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        android:text="@string/launch"
+        android:text="@string/launch_kb"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/knowledge_descrption_text" />
+        app:layout_constraintTop_toBottomOf="@+id/knowledge_description_text" />
+
+    <TextView
+        android:id="@+id/chat_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/chat_description_title"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/knowledge_launch_button" />
+
+    <TextView
+        android:id="@+id/chat_description_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/chat_description_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/chat_title" />
+
+    <Button
+        android:id="@+id/chat_launch_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/launch_chat"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/chat_description_text" />
+
+    <TextView
+        android:id="@+id/auth_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/authentication_description_title"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/chat_launch_button" />
 
     <TextView
         android:id="@+id/authentication_description_text"

--- a/Examples/SnapinsSDKExample/app/src/main/res/values/strings.xml
+++ b/Examples/SnapinsSDKExample/app/src/main/res/values/strings.xml
@@ -123,13 +123,6 @@
     <string name="pref_chat_deployment_id_summary">The Deployment id to use</string>
     <string name="pref_chat_button_id_title">Button Id</string>
     <string name="pref_chat_button_id_summary">The Chat Button Id to use</string>
-    <string name="prechat_agent_info_label">Agent Info Label</string>
-    <string name="prechat_enter_name_label">Enter Name</string>
-    <string name="prechat_example_id_one">ID1</string>
-    <string name="prechat_example_id_two">ID2</string>
-    <string name="prechat_example_selection_one">Example Selection 1</string>
-    <string name="prechat_example_selection_two">Example Selection 2</string>
-    <string name="prechat_selection_label_title">Selection Label Title</string>
     <string name="chat_availability_change_message">Agent Chat Status: %1$s</string>
 
     <!-- ChatBot -->

--- a/Examples/SnapinsSDKExample/app/src/main/res/values/strings.xml
+++ b/Examples/SnapinsSDKExample/app/src/main/res/values/strings.xml
@@ -55,16 +55,18 @@
     <string name="common_version_label">Common Version</string>
 
     <!-- Main Activity -->
-    <string name="launch">Launch Knowledge</string>
+    <string name="launch_kb">Launch Knowledge</string>
+    <string name="launch_chat">Launch Chat</string>
     <string name="login">Login</string>
     <string name="logout">Logout</string>
     <string name="title_activity_knowledge_settings">KnowledgeSettingsActivity</string>
     <string name="knowledge_description_title">Knowledge</string>
-    <string name="knowledge_description_text">The Knowledge feature in the SDK gives you access to your org’s knowledge base directly from within
-                                              your app. Once you point your app to your community URL with the right category group and root data
-                                              category, you can display your knowledge base to your users. Try Knowledge by launching it below.</string>
+    <string name="knowledge_description_text">This feature gives you access to your org’s knowledge base. Once you point your app to your community URL with the right category group and root data
+                                              category, you can display your knowledge base to your users.</string>
+    <string name="chat_description_title">Chat</string>
+    <string name="chat_description_text">This feature gives you access to chat. Once you add the config settings to this app, you can chat with an agent or a chatbot.</string>
     <string name="authentication_description_title">Authentication</string>
-    <string name="authentication_description_text">Use Knowlegde or Cases as an authenticated or unauthenticated user</string>
+    <string name="authentication_description_text">Use Knowledge or Cases as an authenticated or unauthenticated user</string>
 
     <!-- Support FAB -->
     <string name="menu_case">Create Case</string>

--- a/Examples/SnapinsSDKExample/build.gradle
+++ b/Examples/SnapinsSDKExample/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Made the following changes:

1. Added a top-level button for chat so that you don't have to go through the KB interface to get there
2. Moved the chat setup into its own class so that it can be accessed from multiple locations
3. Made the pre-chat form more full-bodied to illustrate a better use case scenario (e.g. it now includes entity mappings)
4. Verified that it works for both Java and Kotlin