### PR TITLE
End chat session and unbind foreground service on main activity destroy

### DIFF
--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/ChatLauncher.java
@@ -1,5 +1,14 @@
 package com.salesforce.snapinssdkexample;
 
+import static com.salesforce.snapinssdkexample.utils.Utils.getBooleanPref;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.view.inputmethod.EditorInfo;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+
 import com.salesforce.android.chat.core.ChatConfiguration;
 import com.salesforce.android.chat.core.model.ChatEntity;
 import com.salesforce.android.chat.core.model.ChatEntityField;
@@ -15,19 +24,11 @@ import com.salesforce.snapinssdkexample.utils.Utils;
 import java.util.Collections;
 import java.util.List;
 
-import android.app.AlertDialog;
-import android.content.Context;
-import android.view.inputmethod.EditorInfo;
-
-import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentActivity;
-
-import static com.salesforce.snapinssdkexample.utils.Utils.getBooleanPref;
-
 public class ChatLauncher {
     private Context context;
     private List<ChatUserData> chatUserData;
     private List<ChatEntity> chatEntities;
+    private ChatUIClient mChatClient;
 
     /**
      * Configures and launches Live Agent Chat
@@ -61,12 +62,19 @@ public class ChatLauncher {
                 .onResult(new Async.ResultHandler<ChatUIClient>() {
                     @Override
                     public void handleResult(Async<?> async, @NonNull ChatUIClient chatUIClient) {
+                        mChatClient = chatUIClient;
                         // Add the configured chat session listener to the Chat UI client
                         chatUIClient.addSessionStateListener(chatListener);
                         // Start the live agent chat session
                         chatUIClient.startChatSession((FragmentActivity) context);
                     }
                 });
+    }
+
+    public void endChatSession() {
+        if (mChatClient != null) {
+            mChatClient.endChatSession();
+        }
     }
 
     /**

--- a/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/activities/MainActivity.java
+++ b/Examples/SnapinsSDKExample/app/src/javaImplDebug/java/com/salesforce/snapinssdkexample/activities/MainActivity.java
@@ -48,6 +48,7 @@ import java.util.Map;
 public class MainActivity extends AppCompatActivity {
     private KnowledgeUI mKnowledgeUI;
     private KnowledgeUIClient mKnowledgeUIClient;
+    private ChatLauncher mChatLauncher;
     private TextView knowledgeLaunchButton;
     private Button caseLaunchButton;
     private Button chatButton;
@@ -71,6 +72,14 @@ public class MainActivity extends AppCompatActivity {
         initializeServiceSDK();
 
         setupButtons();
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (mChatLauncher != null) {
+            mChatLauncher.endChatSession();
+        }
+        super.onDestroy();
     }
 
     @Override
@@ -183,8 +192,8 @@ public class MainActivity extends AppCompatActivity {
      * Launches Chat.
      */
     private void launchChat() {
-        ChatLauncher chat = new ChatLauncher();
-        chat.launchChat(this);
+        mChatLauncher = new ChatLauncher();
+        mChatLauncher.launchChat(this);
     }
 
     /**


### PR DESCRIPTION
Demonstrating how a customer can end a session & unbind the foreground service when the app closes.